### PR TITLE
fix load path for use with rspec and cucumber executables

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -149,4 +149,5 @@ class SimpleCov::Formatter::RcovFormatter
   end
 end
 
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__)))
 require 'simplecov-rcov/version'


### PR DESCRIPTION
After adding this change, i was able to use the rspec command. I was still getting an error from cucumber, which I was able to get past by moving the simplecov configuration block below the require 'cucumber/rails'.
