### PR TITLE
Add ability to change the output path from `/rcov`

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -90,7 +90,7 @@ class SimpleCov::Formatter::RcovFormatter
   end
 
   def self.output_path
-    File.join( SimpleCov.coverage_path, "/rcov" )
+    File.expand_path( ENV['SIMPLECOV_RCOV_RESULTS_PATH'] || "rcov", SimpleCov.coverage_path )
   end
 
   def asset_output_path


### PR DESCRIPTION
The default remains unchanged, but the path can now be changed by setting the `SIMPLECOV_RCOV_RESULTS_PATH` environment variable.

In my case, I want to set it to an empty string so that the coverage report will show up in the same place in a SimpleCov-using 1.9 branch as it does in my Rcov-using 1.8 branch as we do the transition. This is important because Jenkins looks in one place of the coverage file, and the same job is processing both branches.
