### PR TITLE
fix Encoding::UndefinedConversionError

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -47,6 +47,7 @@ class SimpleCov::Formatter::RcovFormatter
 
   def write_file(template, output_filename, binding)
     rcov_result = template.result( binding )
+    rcov_result.force_encoding( Encoding::UTF_8 ) if Encoding.default_external == Encoding::UTF_8 && rcov_result.encoding == Encoding::ASCII_8BIT
 
     File.open( output_filename, "w" ) do |file_result|
      file_result.write rcov_result


### PR DESCRIPTION
If the source code or comments has unicode characters, (and may be in some ruby versions),
rcov_result.encoding results in #<Encoding:ASCII-8BIT>, but OS encoding is UTF-8, and 
conversion happens before file write, and which in turn results in error.

```
~/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/simplecov-rcov-0.2.3/lib/simplecov-rcov.rb:53:in `write': "\xE4" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
```
