### PR TITLE
Preserve template encoding in rendering result

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -46,7 +46,7 @@ class SimpleCov::Formatter::RcovFormatter
   private
 
   def write_file(template, output_filename, binding)
-    rcov_result = template.result( binding )
+    rcov_result = template.result( binding ).force_encoding(template.encoding)
 
     File.open( output_filename, "w" ) do |file_result|
      file_result.write rcov_result


### PR DESCRIPTION
Fix https://github.com/fguillen/simplecov-rcov/issues/20

It seems basically fine to use https://github.com/fguillen/simplecov-rcov/pull/19 for this issue but this patch would be the most backward-compatible and robust.