### PR TITLE
Update rake version to mitigate vulnerability CVE-2020-8130

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,21 @@
 PATH
   remote: .
   specs:
-    simplecov-rcov (0.2.3)
+    simplecov-rcov (0.3.0)
       simplecov (>= 0.4.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    mocha (0.9.12)
-    multi_json (1.3.6)
-    rake (0.9.2)
-    simplecov (0.6.4)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.5.3)
-    simplecov-html (0.5.3)
+    docile (1.4.0)
+    mocha (1.14.0)
+    rake (13.0.6)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
   ruby
@@ -21,5 +23,8 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 1.0.0.rc.6)
   mocha
-  rake
+  rake (>= 12.3.3)
   simplecov-rcov!
+
+BUNDLED WITH
+   1.17.2

--- a/lib/simplecov-rcov/version.rb
+++ b/lib/simplecov-rcov/version.rb
@@ -1,7 +1,7 @@
 module SimpleCov
   module Formatter
     class RcovFormatter
-      VERSION = "0.2.3"
+      VERSION = "0.3.0"
     end
   end
 end

--- a/simplecov-rcov.gemspec
+++ b/simplecov-rcov.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency 'bundler', '>= 1.0.0.rc.6'
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '>=12.3.3'
 end


### PR DESCRIPTION
Only update rake dependency version to > 12.3.3 to abate CVE-2020-8130 vulnerability. 
Also updated mocha while I was at it. 
Gave it a major version bump, to reflect the multi-major version bump of rake from 0.9.2 to 13.0.6. This could arguably be a minor bump for simplecov-rcov.