### PR TITLE
Update simplecov-rcov.rb

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -54,7 +54,7 @@ class SimpleCov::Formatter::RcovFormatter
   end
 
   def template(name)
-    ERB.new(File.read(File.join(File.dirname(__FILE__), '../views/', "#{name}.erb")), nil, '-')
+    ERB.new(File.read(File.join(File.dirname(__FILE__), '../views/', "#{name}.erb")), trim_mode: '-')
   end
 
   def lines(file_list)


### PR DESCRIPTION
fixes `warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments` and `warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead`