### PR TITLE
fix: generated_on is assigned but not used

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -22,8 +22,6 @@ class SimpleCov::Formatter::RcovFormatter
       h[base] = Pathname.new(base).cleanpath.to_s.gsub(%r{^\w:[/\\]}, "").gsub(/\./, "_").gsub(/[\\\/]/, "-") + ".html"
     }
 
-    generated_on = Time.now
-
     @files = result.files
 
     @total_lines =  result.files.map { |e| e.lines.count }.inject(:+)


### PR DESCRIPTION
This prevents the following warning when runnings tests:

```bash
/home/matheus/.rvm/gems/ruby-3.2.2/gems/simplecov-rcov-0.3.3/lib/simplecov-rcov.rb:25: warning: assigned but unused variable - generated_on
```