### PR TITLE
Reinstate `generated_on` variable

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -22,6 +22,8 @@ class SimpleCov::Formatter::RcovFormatter
       h[base] = Pathname.new(base).cleanpath.to_s.gsub(%r{^\w:[/\\]}, "").gsub(/\./, "_").gsub(/[\\\/]/, "-") + ".html"
     }
 
+    @generated_on = Time.now
+
     @files = result.files
 
     @total_lines =  result.files.map { |e| e.lines.count }.inject(:+)

--- a/views/detail.html.erb
+++ b/views/detail.html.erb
@@ -50,7 +50,7 @@
       </tbody>
     </table>
 
-    <p>Generated on <%= generated_on %> with <a href="<%= SimpleCov::Formatter::RcovFormatter::UPSTREAM_URL %>">SimpleCov-RCov <%= SimpleCov::Formatter::RcovFormatter::VERSION %></a></p>
+    <p>Generated on <%= @generated_on %> with <a href="<%= SimpleCov::Formatter::RcovFormatter::UPSTREAM_URL %>">SimpleCov-RCov <%= SimpleCov::Formatter::RcovFormatter::VERSION %></a></p>
 
   </body>
 </html>

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -66,7 +66,7 @@
       </table>
     </div>
 
-    <p>Generated on <%= generated_on %> with <a href="<%= SimpleCov::Formatter::RcovFormatter::UPSTREAM_URL %>">SimpleCov-RCov <%= SimpleCov::Formatter::RcovFormatter::VERSION %></a></p>
+    <p>Generated on <%= @generated_on %> with <a href="<%= SimpleCov::Formatter::RcovFormatter::UPSTREAM_URL %>">SimpleCov-RCov <%= SimpleCov::Formatter::RcovFormatter::VERSION %></a></p>
 
     <script type="text/javascript">
       $(document).ready(function(){$("#report_table").tablesorter({widgets: ['zebra'], textExtraction: 'complex'});});


### PR DESCRIPTION
This variable was removed in https://github.com/fguillen/simplecov-rcov/pull/33 as it appeared to be unused, however it is still being used in views.

Therefore adding it again and making it an instance variable.

Resolves https://github.com/fguillen/simplecov-rcov/issues/34.